### PR TITLE
Generate dagger factories

### DIFF
--- a/lib-android-dagger/build.gradle
+++ b/lib-android-dagger/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'android-apt'
 apply plugin: 'jacoco-android'
 apply plugin: 'me.tatarka.retrolambda'
 
@@ -34,6 +35,8 @@ dependencies {
   provided project(':lib-java-common')
   provided support.annotations
   provided dagger.dagger
+  apt dagger.compiler
+  provided jsr205
 
   testCompile assertJCore
   testCompile junit


### PR DESCRIPTION
Dagger doesn't generate classes like ActivityModule_ProvideActivityFactory
when the module is in other library. I need to test whether this config
will generate and package these classes.
