### PR TITLE
Fix problem with shared preferences set to null

### DIFF
--- a/lib-android/src/main/java/com/devinci/lib/preference/BasePreference.java
+++ b/lib-android/src/main/java/com/devinci/lib/preference/BasePreference.java
@@ -26,7 +26,7 @@ abstract class BasePreference<T> {
     return sharedPreferences.contains(key);
   }
 
-  @SuppressLint("CommitPrefEdits") public void set(T value) {
+  @SuppressLint("CommitPrefEdits") public void set(@Nullable T value) {
     SharedPreferences.Editor editor = sharedPreferences.edit();
     putValue(value, editor);
     if (commit) {

--- a/lib-android/src/main/java/com/devinci/lib/preference/StringPreference.java
+++ b/lib-android/src/main/java/com/devinci/lib/preference/StringPreference.java
@@ -5,15 +5,13 @@ import android.content.SharedPreferences.Editor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import static com.devinci.lib.util.Preconditions.checkNotNull;
-
 /**
  * Shared preference with {@link String} value.
  */
 public class StringPreference extends BasePreference<String> {
 
   public StringPreference(@NonNull SharedPreferences sharedPreferences, @NonNull String key,
-      @NonNull String defaultValue, boolean commit) {
+      @Nullable String defaultValue, boolean commit) {
     super(sharedPreferences, key, defaultValue, commit);
   }
 
@@ -21,13 +19,13 @@ public class StringPreference extends BasePreference<String> {
    * Creates a new instance that uses {@link Editor#apply()} to save changes.
    */
   public static StringPreference newInstance(@NonNull SharedPreferences preferences,
-      @NonNull String key, String defaultValue) {
+      @NonNull String key, @Nullable String defaultValue) {
     return newInstance(preferences, key, defaultValue, false);
   }
 
   public static StringPreference newInstance(@NonNull SharedPreferences preferences,
-      @NonNull String key, String defaultValue, boolean commit) {
-    return new StringPreference(preferences, key, checkNotNull(defaultValue), commit);
+      @NonNull String key, @Nullable String defaultValue, boolean commit) {
+    return new StringPreference(preferences, key, defaultValue, commit);
   }
 
   @Nullable public String get() {
@@ -35,6 +33,11 @@ public class StringPreference extends BasePreference<String> {
   }
 
   @Override void putValue(@Nullable String value, @NonNull Editor editor) {
-    editor.putString(key, value);
+    // Workaround for bug https://code.google.com/p/android/issues/detail?id=64563
+    if (value == null) {
+      editor.remove(key);
+    } else {
+      editor.putString(key, value);
+    }
   }
 }

--- a/lib-android/src/test/java/com/devinci/lib/preference/StringPreferenceTest.java
+++ b/lib-android/src/test/java/com/devinci/lib/preference/StringPreferenceTest.java
@@ -11,7 +11,6 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.shadows.ShadowPreferenceManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.verify;
@@ -31,11 +30,13 @@ import static org.mockito.MockitoAnnotations.initMocks;
     given(mockEditor.remove(anyString())).willReturn(mockEditor);
   }
 
-  @Test public void shouldThrowOnNullDefaultValue() {
-    Throwable throwable =
-        catchThrowable(() -> StringPreference.newInstance(mockSharedPreferences, "key", null));
+  @Test public void shouldReturnDefaultNullValue() {
+    StringPreference stringPreference =
+        StringPreference.newInstance(mockSharedPreferences, "key", null);
 
-    assertThat(throwable).isExactlyInstanceOf(NullPointerException.class).hasNoCause();
+    String value = stringPreference.get();
+
+    assertThat(value).isNull();
   }
 
   @SuppressLint("CommitPrefEdits") @Test public void shouldApplySetOperationByDefault() {
@@ -88,5 +89,16 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
     assertThat(stringPreference.isSet()).isTrue();
     assertThat(stringPreference.get()).isEqualTo(newValue);
+  }
+
+  @Test public void shouldNotBeSetWhenNewValueIsNull() {
+    StringPreference stringPreference =
+        StringPreference.newInstance(sharedPreferences, "key", null);
+    stringPreference.set("old_value");
+
+    stringPreference.set(null);
+
+    assertThat(stringPreference.isSet()).isFalse();
+    assertThat(stringPreference.get()).isNull();
   }
 }


### PR DESCRIPTION
- allows to pass null as a default value to StringPreference
- fixes bug in Android (<=4.3) with setting the value to null
